### PR TITLE
feat: 「地動説」トリガーワード追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const TRIGGER_WORDS: TriggerWord[] = [
   { word: 'おめでとう', title: 'お祝いソング', youtubeId: '3JZ_D3ELwOQ' },
   { word: 'ごめんなさい', title: '女々しくて', youtubeId: 'BC9P3DSZu0A', startSeconds: 27 },
   { word: '異端', title: '怪獣', youtubeId: 'a8dgNdJVluc', startSeconds: 9 },
+  { word: '地動説', title: '怪獣', youtubeId: 'a8dgNdJVluc', startSeconds: 9 },
   { word: '好きです', title: 'ラブ・ストーリーは突然に', youtubeId: 'LDe0rbDromY', startSeconds: 0 },
   // 必要に応じて追加
 ]


### PR DESCRIPTION
## 📝 変更内容

### ✨ 新機能
- **新しいトリガーワード「地動説」を追加**
  - 「異端」と同じ動作を実現
  - サカナクション「怪獣」（Kaiju）が9秒から再生されます
  - YouTube動画ID: a8dgNdJVluc

### 🎯 コンセプト
科学史における「地動説」は当時の常識に反する「異端」な考えとして迫害されました。この歴史的・科学的コンテキストから、「地動説」と「異端」で同じ楽曲（怪獣）が再生される機能を実装しました。

### 🎵 トリガーワード一覧（更新後）
- 「乾杯」→ ファンファーレ（0秒から）
- 「おめでとう」→ お祝いソング（0秒から）
- 「ごめんなさい」→ 女々しくて（27秒から）
- 「異端」→ 怪獣（9秒から）
- 「地動説」→ 怪獣（9秒から）← 新規追加
- 「好きです」→ ラブ・ストーリーは突然に（0秒から）

### ✅ 動作確認済み
- 開発サーバーで正常動作を確認
- 音声認識で「地動説」を検出すると9秒からサカナクション「怪獣」が再生
- 既存の「異端」機能に影響なし